### PR TITLE
Typo: Changed example option attribute

### DIFF
--- a/resources/views/laravel-blade-x/v2/advanced-usage/transforming-data-with-view-models.md
+++ b/resources/views/laravel-blade-x/v2/advanced-usage/transforming-data-with-view-models.md
@@ -63,7 +63,7 @@ All public properties and methods on the view model will be passed to the Blade 
 ```blade
 <select name="{{ $name }}">
     @foreach($options as $value => $label)
-        <option {!! $isSelected($value) ? 'selected="selected"' : '' !!} name="{{ $value }}">{{ $label }}</option>
+        <option {!! $isSelected($value) ? 'selected="selected"' : '' !!} value="{{ $value }}">{{ $label }}</option>
     @endforeach
 </select>
 ```


### PR DESCRIPTION
Changed option attribute from name to value.
With this change works by sending the expected value and not the name/label